### PR TITLE
fix: infer worker metadata from top-level option

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -129,6 +129,29 @@ function wrapPgBossWorkerHandler<Jobs, ResData>(
   }
 }
 
+function warnWhenWorkerOptionsIncludeMetadata<ReqData, ResData>(
+  worker: PgBossWorkerDefinition<ReqData, ResData>,
+) {
+  if (!Object.hasOwn(worker.options ?? {}, 'includeMetadata')) {
+    return
+  }
+
+  console.warn(
+    'pg-boss-registry: worker.options.includeMetadata is ignored; use worker.includeMetadata instead.',
+  )
+}
+
+function getPgBossWorkerOptions<ReqData, ResData>(
+  worker: PgBossWorkerDefinition<ReqData, ResData>,
+) {
+  warnWhenWorkerOptionsIncludeMetadata(worker)
+
+  return {
+    ...(worker.options ?? {}),
+    includeMetadata: worker.includeMetadata === true,
+  }
+}
+
 export async function registerPgBossWorker<ReqData = object, ResData = any>(
   boss: Pick<PgBoss, 'schedule' | 'work'>,
   worker: PgBossWorkerDefinition<ReqData, ResData>,
@@ -147,7 +170,7 @@ export async function registerPgBossWorker<ReqData = object, ResData = any>(
   if (worker.includeMetadata) {
     await boss.work(
       queue,
-      { ...(worker.options ?? {}), includeMetadata: true as const },
+      { ...getPgBossWorkerOptions(worker), includeMetadata: true as const },
       wrapPgBossWorkerHandler(worker.handler, worker.onError),
     )
     return
@@ -155,7 +178,7 @@ export async function registerPgBossWorker<ReqData = object, ResData = any>(
 
   await boss.work(
     queue,
-    worker.options ?? {},
+    getPgBossWorkerOptions(worker),
     wrapPgBossWorkerHandler(worker.handler, worker.onError),
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,7 +386,7 @@ type PgBossWorkerBaseDefinition<ReqData = object, ResData = any> = {
        * after this hook so pg-boss can keep its retry/failure behavior.
        */
       onError?: PgBossWorkerWithMetadataErrorHandler<ReqData>
-      options?: WorkOptions & { includeMetadata: true }
+      options?: WorkOptions
     }
 )
 

--- a/tests/setup-worker-options.test.ts
+++ b/tests/setup-worker-options.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { PgBoss } from 'pg-boss'
+import { registerPgBossWorker } from '../src/index.js'
+
+test('worker registration warns when nested includeMetadata is ignored', async (t) => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (message?: unknown, ...optionalParams: unknown[]) => {
+    warnings.push([message, ...optionalParams].map(String).join(' '))
+  }
+  t.after(() => {
+    console.warn = originalWarn
+  })
+
+  const workCalls: { options: { includeMetadata?: boolean; pollingIntervalSeconds?: number } }[] =
+    []
+  const boss = {
+    async schedule() {},
+    async work(
+      _name: string,
+      options: { includeMetadata?: boolean; pollingIntervalSeconds?: number },
+    ) {
+      workCalls.push({ options })
+      return 'worker-id'
+    },
+  } as unknown as Pick<PgBoss, 'schedule' | 'work'>
+
+  await registerPgBossWorker(boss, {
+    name: 'metadata-worker',
+    includeMetadata: true,
+    options: {
+      includeMetadata: false,
+      pollingIntervalSeconds: 0.5,
+    },
+    async handler() {},
+  })
+  await registerPgBossWorker(boss, {
+    name: 'plain-worker',
+    options: {
+      includeMetadata: true,
+      pollingIntervalSeconds: 0.5,
+    },
+    async handler() {},
+  })
+
+  assert.deepEqual(warnings, [
+    'pg-boss-registry: worker.options.includeMetadata is ignored; use worker.includeMetadata instead.',
+    'pg-boss-registry: worker.options.includeMetadata is ignored; use worker.includeMetadata instead.',
+  ])
+  assert.deepEqual(
+    workCalls.map((call) => call.options.includeMetadata),
+    [true, false],
+  )
+})

--- a/tests/setup-workers.test.ts
+++ b/tests/setup-workers.test.ts
@@ -242,7 +242,6 @@ test('worker registration runs against postgres and close removes active workers
     name: 'metadata-worker',
     includeMetadata: true,
     options: {
-      includeMetadata: true,
       pollingIntervalSeconds: 0.5,
     },
     async handler(jobs) {

--- a/typetests/registry.tst.ts
+++ b/typetests/registry.tst.ts
@@ -1,4 +1,11 @@
-import type { Job, JobSpyInterface, JobWithMetadata, PgBoss, SendOptions } from 'pg-boss'
+import type {
+  Job,
+  JobSpyInterface,
+  JobWithMetadata,
+  PgBoss,
+  SendOptions,
+  WorkOptions,
+} from 'pg-boss'
 import { expect, test } from 'tstyche'
 import {
   asTypedPgBoss,
@@ -136,6 +143,86 @@ test('queue registry workers bind queue names and payload types', () => {
       expect(jobs[0]?.state).type.toBe<
         'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed' | undefined
       >()
+    },
+  })
+})
+
+test('worker metadata is inferred from the top-level includeMetadata option', () => {
+  const queues = definePgBossQueues({
+    'email/send': queue<EmailJob>({ create: true }),
+    cleanup: queue<CleanupJob>({ create: true }),
+    heartbeat: queue<undefined>({ create: true }),
+    reports: queue<ReportJob>({ create: true }),
+  })
+
+  const sharedOptionsWithMetadata: WorkOptions = {
+    includeMetadata: true,
+    pollingIntervalSeconds: 5,
+  }
+  const sharedOptionsWithoutMetadata: WorkOptions = {
+    pollingIntervalSeconds: 5,
+  }
+
+  const metadataWorkerWithNestedOption = queues.worker('reports', {
+    name: 'metadata-report-worker',
+    includeMetadata: true,
+    options: sharedOptionsWithMetadata,
+    async handler(jobs) {
+      expect(jobs[0]?.data.format).type.toBe<'csv' | 'pdf' | undefined>()
+      expect(jobs[0]?.state).type.toBe<
+        'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed' | undefined
+      >()
+    },
+    onError(_error, jobs) {
+      expect(jobs[0]?.data.reportId).type.toBe<string | undefined>()
+      expect(jobs[0]?.state).type.toBe<
+        'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed' | undefined
+      >()
+    },
+  })
+
+  const metadataWorkerWithPlainOptions = queues.worker('reports', {
+    name: 'metadata-report-worker',
+    includeMetadata: true,
+    options: sharedOptionsWithoutMetadata,
+    async handler(jobs) {
+      expect(jobs[0]?.data.format).type.toBe<'csv' | 'pdf' | undefined>()
+      expect(jobs[0]?.state).type.toBe<
+        'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed' | undefined
+      >()
+    },
+    onError(_error, jobs) {
+      expect(jobs[0]?.data.reportId).type.toBe<string | undefined>()
+      expect(jobs[0]?.state).type.toBe<
+        'created' | 'retry' | 'active' | 'completed' | 'cancelled' | 'failed' | undefined
+      >()
+    },
+  })
+
+  expect(metadataWorkerWithNestedOption.queue).type.toBe<'reports'>()
+  expect(metadataWorkerWithPlainOptions.queue).type.toBe<'reports'>()
+  expect(metadataWorkerWithNestedOption.options?.pollingIntervalSeconds).type.toBe<
+    number | undefined
+  >()
+  expect(metadataWorkerWithPlainOptions.options?.pollingIntervalSeconds).type.toBe<
+    number | undefined
+  >()
+
+  queues.worker('reports', {
+    name: 'plain-report-worker',
+    options: sharedOptionsWithMetadata,
+    async handler(jobs) {
+      expect(jobs[0]?.data.format).type.toBe<'csv' | 'pdf' | undefined>()
+      expect(jobs[0]!).type.not.toHaveProperty('state')
+    },
+  })
+
+  queues.worker('reports', {
+    name: 'plain-report-worker',
+    options: sharedOptionsWithoutMetadata,
+    async handler(jobs) {
+      expect(jobs[0]?.data.format).type.toBe<'csv' | 'pdf' | undefined>()
+      expect(jobs[0]!).type.not.toHaveProperty('state')
     },
   })
 })


### PR DESCRIPTION
## Summary

- Keep registry worker `options` compatible with pg-boss `WorkOptions`.
- Infer handler metadata types only from top-level `worker.includeMetadata`.
- Normalize runtime registration so top-level `includeMetadata` wins over nested `options.includeMetadata`.
- Warn when `worker.options.includeMetadata` is provided because that nested value is ignored.
- Add type and unit regression coverage for shared `WorkOptions` values and override behavior.

## Root Cause

`includeMetadata` changes the handler job type, so the registry needs one discriminator for type inference. The top-level worker `includeMetadata` property now owns that typing decision, while `options` remains pg-boss-compatible for existing callers.

## Behavior

If callers pass both `worker.includeMetadata` and `worker.options.includeMetadata`, the top-level value is used. The nested `options.includeMetadata` value is ignored and emits a warning.

## Validation

- `npm run type-test`
- `npm run typecheck`
- `npm run lint`
- `node --import tsx --test tests/setup-worker-options.test.ts`
- `npm run build`