### PR TITLE
Infer typed boss and setup handle from queue registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ const worker = queues.worker('email/send', {
 methods narrowed to the known registry keys and payload types. The underlying
 runtime object is not wrapped.
 
+When `setupPgBoss` receives a typed `queueRegistry`, the returned `setup.boss`
+is already typed from that registry.
+
 Typed methods include `send`, `sendAfter`, `sendThrottled`, `sendDebounced`,
 `insert`, `fetch`, `work`, job commands, queue commands, queue getters,
 schedules, and spies.
 
 ```ts
-const typedBoss = asTypedPgBoss<Queues>(boss)
+const typedBoss = setup.boss
 
 await typedBoss.send('email/send', { userId: 'user_123' })
 await typedBoss.fetch('email/send')

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,11 +2,13 @@ import type { PgBoss } from 'pg-boss'
 import type {
   PgBossDefinedQueueRegistry,
   PgBossQueueDefinition,
+  PgBossQueuesFromRegistry,
   PgBossRegistrySetupOptions,
   PgBossScheduleDefinition,
   PgBossSetupContext,
   PgBossWorkerDefinition,
   PgBossWorkerRegistration,
+  TypedPgBoss,
 } from './types.js'
 
 type PgBossWorkerQueueBinding = {
@@ -215,7 +217,11 @@ function assertPgBossWorkerFactoryContext<Context>(options: PgBossRegistrySetupO
   throw new Error('setupPgBoss requires options.context when workers include factory functions')
 }
 
-type PgBossSetupHandle = Awaited<ReturnType<typeof createPgBossSetup>>
+type PgBossSetupHandle<Boss = PgBoss> = {
+  boss: Boss
+  workers: PgBossWorkerDefinition<any>[]
+  close(): Promise<void>
+}
 
 export function setupPgBoss<
   QueueRegistry extends PgBossDefinedQueueRegistry<any, any>,
@@ -228,7 +234,7 @@ export function setupPgBoss<
   > & {
     queueRegistry: QueueRegistry
   },
-): Promise<PgBossSetupHandle>
+): Promise<PgBossSetupHandle<TypedPgBoss<PgBossQueuesFromRegistry<QueueRegistry>>>>
 export function setupPgBoss<Context = unknown>(
   boss: PgBoss,
   options?: PgBossRegistrySetupOptions<Context> & { queueRegistry?: never },
@@ -236,14 +242,14 @@ export function setupPgBoss<Context = unknown>(
 export async function setupPgBoss<Context = unknown>(
   boss: PgBoss,
   options: PgBossRegistrySetupOptions<Context> = {},
-) {
+): Promise<PgBossSetupHandle<any>> {
   return createPgBossSetup(boss, options)
 }
 
 async function createPgBossSetup<Context = unknown>(
   boss: PgBoss,
   options: PgBossRegistrySetupOptions<Context> = {},
-) {
+): Promise<PgBossSetupHandle> {
   assertPgBossWorkerFactoryContext(options)
 
   const start = options.start ?? false

--- a/typetests/registry.tst.ts
+++ b/typetests/registry.tst.ts
@@ -13,6 +13,7 @@ import {
   type PgBossQueuesFromRegistry,
   type PgBossRegistrySetupOptions,
   type PgBossScheduleDefinition,
+  type PgBossWorkerDefinition,
   queue,
   setupPgBoss,
   type TypedPgBoss,
@@ -318,14 +319,19 @@ test('setupPgBoss returns a typed boss from the queue registry', () => {
       Promise<string | null>
     >()
     expect(setup.boss.send('heartbeat')).type.toBe<Promise<string | null>>()
+    expect(setup.workers).type.toBe<PgBossWorkerDefinition<any>[]>()
+    expect(setup.close()).type.toBe<Promise<void>>()
 
     expect(setup.boss.send).type.not.toBeCallableWith('missing')
     expect(setup.boss.send).type.not.toBeCallableWith('email/send', { userId: 123 })
     expect(setup.boss.send).type.not.toBeCallableWith('cleanup', { userId: 'user_123' })
+    expect(setup.close).type.not.toBeCallableWith({ force: true })
   })
 
   setupPgBoss(boss).then((setup) => {
     expect(setup.boss).type.toBe<PgBoss>()
+    expect(setup.workers).type.toBe<PgBossWorkerDefinition<any>[]>()
+    expect(setup.close()).type.toBe<Promise<void>>()
   })
 })
 

--- a/typetests/registry.tst.ts
+++ b/typetests/registry.tst.ts
@@ -296,12 +296,36 @@ test('queue registry can carry worker factory context type', () => {
       queueRegistry: queues,
       workers: [worker],
     }),
-  ).type.toBeAssignableTo<Promise<{ boss: PgBoss }>>()
+  ).type.toBeAssignableTo<Promise<{ boss: TypedPgBoss<PgBossQueuesFromRegistry<typeof queues>> }>>()
 
   expect(setupPgBoss).type.not.toBeCallableWith(boss, {
     context: {},
     queueRegistry: queues,
     workers: [worker],
+  })
+})
+
+test('setupPgBoss returns a typed boss from the queue registry', () => {
+  const queues = definePgBossQueues({
+    'email/send': queue<EmailJob>({ create: true }),
+    cleanup: queue<CleanupJob>({ create: true }),
+    heartbeat: queue<undefined>({ create: true }),
+  })
+
+  setupPgBoss(boss, { queueRegistry: queues }).then((setup) => {
+    expect(setup.boss).type.toBe<TypedPgBoss<PgBossQueuesFromRegistry<typeof queues>>>()
+    expect(setup.boss.send('email/send', { userId: 'user_123' })).type.toBe<
+      Promise<string | null>
+    >()
+    expect(setup.boss.send('heartbeat')).type.toBe<Promise<string | null>>()
+
+    expect(setup.boss.send).type.not.toBeCallableWith('missing')
+    expect(setup.boss.send).type.not.toBeCallableWith('email/send', { userId: 123 })
+    expect(setup.boss.send).type.not.toBeCallableWith('cleanup', { userId: 'user_123' })
+  })
+
+  setupPgBoss(boss).then((setup) => {
+    expect(setup.boss).type.toBe<PgBoss>()
   })
 })
 
@@ -345,7 +369,7 @@ test('setup options infer inline worker factory context from context option', ()
         }),
       ],
     }),
-  ).type.toBeAssignableTo<Promise<{ boss: PgBoss }>>()
+  ).type.toBeAssignableTo<Promise<{ boss: TypedPgBoss<PgBossQueuesFromRegistry<typeof queues>> }>>()
 })
 
 test('asTypedPgBoss wraps send variants and insert with typed payloads', () => {


### PR DESCRIPTION
## Summary
- Make `setupPgBoss` return a typed `boss` when a typed `queueRegistry` is provided.
- Keep the untyped `PgBoss` return path for calls without a registry.
- Add type tests for `setup.boss`, `setup.workers`, and `setup.close()`.
- Update the README example to use the typed `setup.boss` handle.

## Testing
- Type tests updated to cover typed and untyped `setupPgBoss` return values.
- `typecheck`, `type-test`, `lint`, and `build` passed locally.